### PR TITLE
Add manifest_version to manifest.json

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,4 +1,5 @@
 {
+  "manifest-version": 2,
   "name": "Cloud9 button for GitHub",
   "version": "1.0.8",
   "description": "This extension adds a button to GitHub that lets you edit your projects directly in Cloud9 IDE",


### PR DESCRIPTION
Chrome is saying it can't install the extension without this key (and a value of 2).