### PR TITLE
Use SSH for all clones

### DIFF
--- a/githubc9.js
+++ b/githubc9.js
@@ -1,10 +1,10 @@
 (function () {
-    
+
 var defaultBgImage = "url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABIAAAALCAYAAAByF90EAAAAGXRFWHRTb2Z0d2FyZQBBZG9iZSBJbWFnZVJlYWR5ccllPAAAAZpJREFUeNp8kr9Lw0AUx5ukTdMfaWvALlKyKKWNGBBxkIjUSagoKbQ4Z01HcayD0MFJcChF7f9Q6lJQQRycpLM4tC4luhVd1Kbn90ojJUYPPlzu7r1vvvfeMYQQ3x9DBPJk/gAvoA+8E6iQByJYKxaLeiAQuGEYZhCNRh/T6fQRUjivHPcGDwSglkolHQJvEDpF8gaEzFAo1Adn/wnR5CWw3mq1dhuNRikYDN5D6AR7i7lcbp7GVavVAsdxtmmaBaznADMtRBcrNDmZTHb8fj9xYFk2jzMJrq4hmsX3ajwe79K4VCp1q6rqMYQ5R2jGsqzNRCLxzPM8mSYcDhuTZuQzmcwydRyLxazpGFEUrxyhWcMw9nEV4kaSpG6tVlMm9hfq9fqeVxxMbY0LrOv6IYpIvBAEgcDtAeI0RVGaXjEoQZmF7U9ZlpvD4fALdfC5wR+f2u12p1KpZHu93rb73LZt32g0evhpH+5eph2hDiKRCEG7x8DNu6ZpF5gHzh6FOqENgZHzX+8IIwsuwevkBf8Ffel3YMfJ/RZgALTrMYKs/GM2AAAAAElFTkSuQmCC)";
 
 
-    
-// new layout     
+
+// new layout
 var target = document.getElementsByClassName("clone-options")[0];
 if (target)
     newLayout(target);
@@ -12,7 +12,7 @@ else
     oldLayout();
 
 
-function oldLayout() {    
+function oldLayout() {
     // this is just github!
     if (!document.getElementsByClassName("native-clones").length || !document.getElementsByClassName("public_clone_url").length)
     	return;
@@ -79,7 +79,7 @@ function oldLayout() {
 
     	return true;
     });
-    
+
     // and add it to the DOM
     target.parentNode.insertBefore(li, target);
 }
@@ -92,22 +92,18 @@ function newLayout(target) {
     link.rel = "nofollow";
     link.target = "_blank";
 
-    var isPrivate = document.getElementsByClassName("private").length > 0;
     var user = document.querySelectorAll(".author>a>span")[0].textContent;
     var repo = document.querySelectorAll(".js-current-repository")[0].textContent;
-    
-    if (isPrivate)
-        var url = "git@github.com:" + user + "/" + repo + ".git";
-    else
-        var url = "git://github.com/" + user + "/" + repo + ".git";
-        
+
+    var url = "git@github.com:" + user + "/" + repo + ".git";
+
     link.href = "https://c9.io/open/git/?url=" + url;
-    
+
     var icon = document.createElement("span");
-    
+
     link.appendChild(icon);
     link.appendChild(document.createTextNode("Clone in Cloud9"));
-    
+
     target.parentNode.insertBefore(link, target.nextSibling);
 }
 


### PR DESCRIPTION
*(I recommend merging #11 instead of this individually.)*

---

This matches the behavior used when cloning projects from the dashboard. (I think it's safe to assume the user's Cloud9 account is linked to GitHub for the purposes of this extension.)